### PR TITLE
Fix gain reduction graph and update to latest Cyma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "cyma"
 version = "0.1.0"
-source = "git+https://github.com/223230/cyma.git#a58addb981374235020a7add0c904b1217f307d3"
+source = "git+https://github.com/223230/cyma.git#f62bde104887b4b43d4f81f01624077ba8444e4f"
 dependencies = [
  "lazy_static",
  "nih_plug",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,11 +1122,13 @@ dependencies = [
 [[package]]
 name = "cyma"
 version = "0.1.0"
-source = "git+https://github.com/223230/cyma.git#6e54760b784f3eb9437b97f10499319ccade61a9"
+source = "git+https://github.com/223230/cyma.git#a58addb981374235020a7add0c904b1217f307d3"
 dependencies = [
  "lazy_static",
  "nih_plug",
  "nih_plug_vizia",
+ "realfft",
+ "triple_buffer",
 ]
 
 [[package]]
@@ -2409,6 +2411,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2423,6 +2434,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.55",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2839,6 +2859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "primal-check"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df7f93fd637f083201473dab4fee2db4c429d32e55e3299980ab3957ab916a0"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2984,6 +3013,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953d9f7e5cdd80963547b456251296efc2626ed4e3cbf36c869d9564e0220571"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,6 +3114,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43806561bc506d0c5d160643ad742e3161049ac01027b5e6d7524091fd401d86"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+ "version_check",
 ]
 
 [[package]]
@@ -3333,6 +3386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
 name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3562,6 +3621,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
+name = "triple_buffer"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "316e1ab00252ce5980b8a70eb50f9818f47a20d341394c56ffab88e764b3caed"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -24,7 +24,7 @@ struct LambData {
     // peak_meter: Arc<AtomicF32>,
     gain_reduction_left: Arc<AtomicF32>,
     gain_reduction_right: Arc<AtomicF32>,
-    peak_buffer: Arc<Mutex<MinimaBuffer>>,
+    gr_buffer: Arc<Mutex<MinimaBuffer>>,
 }
 
 impl LambData {
@@ -33,14 +33,14 @@ impl LambData {
         // peak_meter: Arc<AtomicF32>,
         gain_reduction_left: Arc<AtomicF32>,
         gain_reduction_right: Arc<AtomicF32>,
-        peak_buffer: Arc<Mutex<MinimaBuffer>>,
+        gr_buffer: Arc<Mutex<MinimaBuffer>>,
     ) -> Self {
         Self {
             params,
             // peak_meter,
             gain_reduction_left,
             gain_reduction_right,
-            peak_buffer,
+            gr_buffer,
         }
     }
 }
@@ -60,7 +60,7 @@ pub(crate) fn create(
     // peak_meter: Arc<AtomicF32>,
     gain_reduction_left: Arc<AtomicF32>,
     gain_reduction_right: Arc<AtomicF32>,
-    peak_buffer: Arc<Mutex<MinimaBuffer>>,
+    gr_buffer: Arc<Mutex<MinimaBuffer>>,
     editor_state: Arc<ViziaState>,
 ) -> Option<Box<dyn Editor>> {
     create_vizia_editor(editor_state, ViziaTheming::Custom, move |cx, _| {
@@ -76,7 +76,7 @@ pub(crate) fn create(
             // peak_meter: peak_meter.clone(),
             gain_reduction_left: gain_reduction_left.clone(),
             gain_reduction_right: gain_reduction_right.clone(),
-            peak_buffer: peak_buffer.clone(),
+            gr_buffer: gr_buffer.clone(),
         }
         .build(cx);
 
@@ -407,9 +407,10 @@ fn peak_graph(cx: &mut Context) {
             )
                 .color(Color::rgb(60, 60, 60));
 
-            Graph::new(cx, LambData::peak_buffer, (-32.0, 6.0), ValueScaling::Decibels)
-                .color(Color::rgba(0, 0, 0, 160))
-                .background_color(Color::rgba(16, 16, 16, 60));
+            Graph::new(cx, LambData::gr_buffer, (-32.0, 0.0), ValueScaling::Decibels)
+                .color(Color::rgba(160, 0, 0, 160))
+                .background_color(Color::rgba(255, 16, 16, 60))
+                .should_fill_from_top(true);
         })
         // .background_color(Color::rgb(16, 16, 16))
             ;
@@ -435,7 +436,7 @@ fn peak_graph(cx: &mut Context) {
 
         Meter::new(
             cx,
-            LambData::peak_buffer,
+            LambData::gr_buffer,
             (-32.0, 6.0),
             ValueScaling::Decibels,
             Orientation::Vertical,

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -402,25 +402,26 @@ fn peak_graph(cx: &mut Context) {
             Grid::new(
                 cx,
                 ValueScaling::Linear,
-                (-32.0, 0.0),
-                vec![-6.0, -12.0, -18.0, -24.0, -30.0],
+                (-32.0, 6.0),
+                vec![0.0, -6.0, -12.0, -18.0, -24.0, -30.0],
                 Orientation::Vertical
             )
                 .color(Color::rgb(60, 60, 60));
 
-            Graph::new(cx, LambData::gr_buffer, (-32.0, 0.0), ValueScaling::Decibels)
+            Graph::new(cx, LambData::gr_buffer, (-32.0, 6.0), ValueScaling::Decibels)
                 .color(Color::rgba(160, 0, 0, 160))
                 .background_color(Color::rgba(255, 16, 16, 60))
-                .should_fill_from_top(true);
+                .fill_from(0.0);
         })
         // .background_color(Color::rgb(16, 16, 16))
             ;
 
         UnitRuler::new(
             cx,
-            (-32.0, 0.0),
+            (-32.0, 6.0),
             ValueScaling::Linear,
             vec![
+                (-0.0, "0db"),
                 (-6.0, "-6db"),
                 (-12.0, "-12db"),
                 (-18.0, "-18db"),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -15,6 +15,7 @@ use cyma::{
         Graph, Grid, Meter, UnitRuler,
     },
 };
+use cyma::visualizers::GraphModifiers;
 
 include!("gain_reduction_meter.rs");
 
@@ -401,8 +402,8 @@ fn peak_graph(cx: &mut Context) {
             Grid::new(
                 cx,
                 ValueScaling::Linear,
-                (-32.0, 8.0),
-                vec![6.0, 0.0, -6.0, -12.0, -18.0, -24.0, -30.0],
+                (-32.0, 0.0),
+                vec![-6.0, -12.0, -18.0, -24.0, -30.0],
                 Orientation::Vertical
             )
                 .color(Color::rgb(60, 60, 60));
@@ -417,11 +418,9 @@ fn peak_graph(cx: &mut Context) {
 
         UnitRuler::new(
             cx,
-            (-32.0, 8.0),
+            (-32.0, 0.0),
             ValueScaling::Linear,
             vec![
-                (6.0, "6db"),
-                (0.0, "0db"),
                 (-6.0, "-6db"),
                 (-12.0, "-12db"),
                 (-18.0, "-18db"),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -9,7 +9,8 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 use cyma::{
-    utils::{PeakBuffer, ValueScaling},
+    utils::{MinimaBuffer},
+    prelude::*,
     visualizers::{
         Graph, Grid, Meter, UnitRuler,
     },
@@ -23,7 +24,7 @@ struct LambData {
     // peak_meter: Arc<AtomicF32>,
     gain_reduction_left: Arc<AtomicF32>,
     gain_reduction_right: Arc<AtomicF32>,
-    peak_buffer: Arc<Mutex<PeakBuffer>>,
+    peak_buffer: Arc<Mutex<MinimaBuffer>>,
 }
 
 impl LambData {
@@ -32,7 +33,7 @@ impl LambData {
         // peak_meter: Arc<AtomicF32>,
         gain_reduction_left: Arc<AtomicF32>,
         gain_reduction_right: Arc<AtomicF32>,
-        peak_buffer: Arc<Mutex<PeakBuffer>>,
+        peak_buffer: Arc<Mutex<MinimaBuffer>>,
     ) -> Self {
         Self {
             params,
@@ -59,7 +60,7 @@ pub(crate) fn create(
     // peak_meter: Arc<AtomicF32>,
     gain_reduction_left: Arc<AtomicF32>,
     gain_reduction_right: Arc<AtomicF32>,
-    peak_buffer: Arc<Mutex<PeakBuffer>>,
+    peak_buffer: Arc<Mutex<MinimaBuffer>>,
     editor_state: Arc<ViziaState>,
 ) -> Option<Box<dyn Editor>> {
     create_vizia_editor(editor_state, ViziaTheming::Custom, move |cx, _| {
@@ -399,17 +400,16 @@ fn peak_graph(cx: &mut Context) {
         ZStack::new(cx, |cx| {
             Grid::new(
                 cx,
+                ValueScaling::Linear,
                 (-32.0, 8.0),
-                0.0,
                 vec![6.0, 0.0, -6.0, -12.0, -18.0, -24.0, -30.0],
+                Orientation::Vertical
             )
-                .color(Color::rgb(60, 60, 60))
-                ;
+                .color(Color::rgb(60, 60, 60));
 
             Graph::new(cx, LambData::peak_buffer, (-32.0, 6.0), ValueScaling::Decibels)
                 .color(Color::rgba(0, 0, 0, 160))
-                .background_color(Color::rgba(16, 16, 16, 60))
-                ;
+                .background_color(Color::rgba(16, 16, 16, 60));
         })
         // .background_color(Color::rgb(16, 16, 16))
             ;
@@ -417,6 +417,7 @@ fn peak_graph(cx: &mut Context) {
         UnitRuler::new(
             cx,
             (-32.0, 8.0),
+            ValueScaling::Linear,
             vec![
                 (6.0, "6db"),
                 (0.0, "0db"),
@@ -439,10 +440,9 @@ fn peak_graph(cx: &mut Context) {
             ValueScaling::Decibels,
             Orientation::Vertical,
         )
-        .width(Pixels(32.0))
-        .color(Color::rgb(0, 0, 0))
-        .background_color(Color::rgb(80, 80, 80))
-            ;
+            .width(Pixels(32.0))
+            .color(Color::rgb(0, 0, 0))
+            .background_color(Color::rgb(80, 80, 80));
     })
         .top(Pixels(13.0))
     // .height(Pixels(280.0))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,12 @@ impl Plugin for Lamb {
         );
         let latency_samples = self.dsp.get_param(LATENCY_PI).expect("no latency read") as u32;
         context.set_latency_samples(latency_samples);
+        
+        let output = buffer.as_slice();
+        for i in 0..count as usize {
+            output[0][i] = self.temp_output_buffer_l[i] as f32;
+            output[1][i] = self.temp_output_buffer_r[i] as f32;
+        }
 
         if self.params.editor_state.is_open() {
             self.gain_reduction_left.store(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex};
 mod buffer;
 mod dsp;
 use buffer::*;
-use cyma::utils::{PeakBuffer, VisualizerBuffer};
+use cyma::utils::{MinimaBuffer, VisualizerBuffer};
 
 use default_boxed::DefaultBoxed;
 
@@ -42,7 +42,7 @@ pub struct Lamb {
     gain_reduction_right: Arc<AtomicF32>,
 
     // These buffers will hold the sample data for the visualizers.
-    peak_buffer: Arc<Mutex<PeakBuffer>>,
+    peak_buffer: Arc<Mutex<MinimaBuffer>>,
 }
 impl Default for Lamb {
     fn default() -> Self {
@@ -64,7 +64,7 @@ impl Default for Lamb {
             temp_output_buffer_gr_l : f64::default_boxed_array::<MAX_SOUNDCARD_BUFFER_SIZE>(),
             temp_output_buffer_gr_r : f64::default_boxed_array::<MAX_SOUNDCARD_BUFFER_SIZE>(),
             sample_rate: 48000.0,
-            peak_buffer: Arc::new(Mutex::new(PeakBuffer::new(800, 48000.0, 10.0))),
+            peak_buffer: Arc::new(Mutex::new(MinimaBuffer::new(800, 10.0, 10.0))),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub struct Lamb {
     gain_reduction_right: Arc<AtomicF32>,
 
     // These buffers will hold the sample data for the visualizers.
-    peak_buffer: Arc<Mutex<MinimaBuffer>>,
+    gr_buffer: Arc<Mutex<MinimaBuffer>>,
 }
 impl Default for Lamb {
     fn default() -> Self {
@@ -64,7 +64,7 @@ impl Default for Lamb {
             temp_output_buffer_gr_l : f64::default_boxed_array::<MAX_SOUNDCARD_BUFFER_SIZE>(),
             temp_output_buffer_gr_r : f64::default_boxed_array::<MAX_SOUNDCARD_BUFFER_SIZE>(),
             sample_rate: 48000.0,
-            peak_buffer: Arc::new(Mutex::new(MinimaBuffer::new(800, 10.0, 10.0))),
+            gr_buffer: Arc::new(Mutex::new(MinimaBuffer::new(800, 10.0, 0.0))),
         }
     }
 }
@@ -133,7 +133,7 @@ impl Plugin for Lamb {
 
         self.sample_rate = buffer_config.sample_rate;
 
-        match self.peak_buffer.lock() {
+        match self.gr_buffer.lock() {
             Ok(mut buffer) => {
                 buffer.set_sample_rate(buffer_config.sample_rate);
             }
@@ -154,7 +154,7 @@ impl Plugin for Lamb {
             // self.peak_meter.clone(),
             self.gain_reduction_left.clone(),
             self.gain_reduction_right.clone(),
-            self.peak_buffer.clone(),
+            self.gr_buffer.clone(),
             self.params.editor_state.clone(),
         )
     }
@@ -234,7 +234,7 @@ impl Plugin for Lamb {
             );
 
             for i in 0..count as usize {
-                self.peak_buffer
+                self.gr_buffer
                     .lock()
                     .unwrap()
                     .enqueue((self.temp_output_buffer_gr_l[i] + self.temp_output_buffer_gr_l[i]) as f32 / 2.0);


### PR DESCRIPTION
Fixes the gain reduction curve.
- The latest version of Cyma is used
- The gain reduction is now stored inside a `MinimaBuffer`
- The buffer gets enqueued into through its `enqueue` function, instead of the `enqueue_buffer` function
- The gain reduction graph is drawn from 0dB downwards